### PR TITLE
Add incident deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# pdcrier
+
+## 0.1.3
+
+First release.
+
+## 0.2.0
+
+Adds use of `incident_key` to prevent unwanted alert replication.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help:
 	@echo "format: Reformat all python files with black"
 	@echo "tests: Run tests with nosetest"
 	@echo "verbose_tests: Run tests with nosetest -v"
+	@echo "image: Build a docker image (arm7, arm64, amd64)"
 
 f: format
 t: test
@@ -39,5 +40,8 @@ build: distclean format
 image: Dockerfile build
 	docker buildx build --platform linux/arm/v7,linux/amd64,linux/arm64 --push -t unixorn/pdcrier .
 
-amd: Dockerfile build
-	docker buildx build --platform linux/amd64 --load -t unixorn/pdcrier .
+local: Dockerfile build
+	docker buildx build --load -t unixorn/pdcrier .
+
+publish: format build
+	poetry publish

--- a/pdcrier/cli/alerts.py
+++ b/pdcrier/cli/alerts.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 #
-# Create a pagerduty alert
+# Create a pagerduty alert from the command line
 #
 # Copyright 2022, Joe Block <jpb@unixorn.net>
 # License: Apache 2.0
 
 import argparse
 import logging
-import os
+import sys
 
 from pdcrier.pagerduty import PagerDuty, loadCrierSettings
 
@@ -26,24 +26,19 @@ def parseCLI():
         choices=["DEBUG", "INFO", "ERROR", "WARNING", "CRITICAL"],
         default="INFO",
     )
-    if "HOME" in os.environ:
-        parser.add_argument(
-            "--settings-file",
-            "--settings",
-            type=str,
-            help="Path to a settings file. Settings in the file are overridden by command line options",
-            default=f"{os.environ.get('HOME')}/.hass-tools/pagerduty.yaml",
-        )
-    else:
-        parser.add_argument(
-            "--settings-file",
-            "--settings",
-            type=str,
-            default="/config/pagerduty.yaml",
-            help="Path to a settings file. Settings in the file are overridden by command line options",
-        )
-
+    parser.add_argument(
+        "--settings-file",
+        "--settings",
+        type=str,
+        default="/config/pagerduty.yaml",
+        help="Path to a settings file. Settings in the file are overridden by command line options",
+    )
     # Alert options
+    parser.add_argument(
+        "--incident-key",
+        help="Incident key - used to ensure no duplicate incidents. Will default to title if unset",
+        type=str,
+    )
     parser.add_argument(
         "--message",
         help="Alert message body - this won't be visible in SMSes",
@@ -53,7 +48,7 @@ def parseCLI():
     parser.add_argument("--service-id", help="Service ID to create an alert")
     parser.add_argument(
         "--title",
-        help="Title of alert - this is all you'll see via SMS",
+        help="Title of alert - this is all you'll see via SMS, so be specific",
         type=str,
         required=True,
     )
@@ -73,17 +68,47 @@ def alerter():
     """
     cli = parseCLI()
     settings = loadCrierSettings(cli=cli)
+    if "incident_key" not in settings:
+        logging.warning(f"incident_key not specified, using title '{cli.title}'")
+        settings["incident_key"] = cli.title
+
     pd = PagerDuty(
         api_token=settings["pagerduty-api-token"], sender=settings["default-sender"]
     )
     incident = pd.createIncident(
-        title=cli.title, service_id=settings["service_id"], message=cli.message
+        title=cli.title,
+        service_id=settings["service_id"],
+        incident_key=settings["incident_key"],
+        message=cli.message,
     )
-    logging.debug(f"Created incident {incident}.")
-    logging.info(f"Incident number: {incident['incident_number']}")
-    logging.info(f"Incident title: {incident['title']}")
-    logging.info(f"Description: {incident['description']}")
-    logging.info(f"Created At: {incident['created_at']}")
+    try:
+        logging.debug(f"Created incident {incident}.")
+        logging.info(f"Incident title: {incident['title']}")
+        logging.info(f"Incident number: {incident['incident_number']}")
+        if "incident_key" in incident:
+            logging.info(f"Incident key: {incident['incident_key']}")
+        else:
+            logging.debug("No incident key, allowing duplicates")
+        logging.info(f"Description: {incident['description']}")
+        logging.info(f"Created At: {incident['created_at']}")
+    except KeyError:
+        if "exception-response" in incident:
+            error_status = 13
+            error = incident["exception-response"].response.json()["error"]
+            for error_message in error["errors"]:
+                logging.warning(f"{error_message}")
+                if (
+                    error_message
+                    == "Open incident with matching dedup key already exists on this service"
+                ):
+                    # We don't want shell scripts calling us to fail when an
+                    # incident already exists, so we explicitly exit 0 when
+                    # we find a duplicate.
+                    error_status = 0
+                    logging.warning("Do not need a new incident, one already exists.")
+            if error_status != 0:
+                logging.error("Could not create new incident!")
+            sys.exit(error_status)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdcrier"
-version = "0.1.3"
+version = "0.2.0"
 license = "Apache 2.0"
 description = "Wrapper scripts for creating PagerDuty alerts"
 authors = ["Joe Block <jpb@unixorn.net>"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add incident de-duplication by using `incident_key`. We will no longer spam multiple incidents when you try to create multiple incidents on the same service with the same title.

- Pass PagerDuty an `incident_key` when creating new alerts so we don't generate duplicate incidents for the same issue.  If we don't get an incident key, default to using the message title.
- Display incident key in created incidents when present
- Catch exception when there's a duplicated `incident_key` and treat that as not being an error
- Print the PagerDuty errors when we fail to create an incident.

It's usually because there's already an incident with that incident_key and PagerDuty is refusing to duplicate it, but whatever it is, log whatever PagerDuty is complaining about.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates
- [x] Bugfix
- [x] New feature

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that any links added/updated in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
